### PR TITLE
Batch interface: Add delete range function

### DIFF
--- a/devnulldb/devnulldb.go
+++ b/devnulldb/devnulldb.go
@@ -119,6 +119,11 @@ func (b *batch) Replay(w kvdb.Writer) error {
 	return nil
 }
 
+// DeleteRange deletes a range of the batch.
+func (b *batch) DeleteRange(start, end []byte) error {
+	return nil
+}
+
 // iterator can walk over the (potentially partial) keyspace of a memory key
 // value store. Internally it is a deep copy of the entire iterated state,
 // sorted by keys.

--- a/flushable/flushable.go
+++ b/flushable/flushable.go
@@ -556,6 +556,20 @@ func (b *cacheBatch) Replay(w kvdb.Writer) error {
 	return nil
 }
 
+// DeleteRange deletes a range of the batch.
+func (b *cacheBatch) DeleteRange(start, end []byte) error {
+	// delete all keys in range
+	for it := b.db.modified.Iterator(); it.Next(); {
+		key := []byte(it.Key().(string))
+		if bytes.Compare(key, start) < 0 || bytes.Compare(key, end) >= 0 {
+			continue // skip keys that are not in the range
+		}
+		b.writes = append(b.writes, kv{common.CopyBytes(key), nil})
+		b.size += len(key)
+	}
+	return nil
+}
+
 // Snapshot is a DB snapshot.
 type Snapshot struct {
 	flushableReader

--- a/interface.go
+++ b/interface.go
@@ -33,6 +33,9 @@ type Batch interface {
 
 	// Replay replays the batch contents.
 	Replay(w Writer) error
+
+	// DeleteRange deletes the range [start, end) from batch.
+	DeleteRange(start []byte, end []byte) error
 }
 
 // Iterator iterates over a database's key/value pairs in ascending key order.

--- a/leveldb/leveldb.go
+++ b/leveldb/leveldb.go
@@ -323,6 +323,15 @@ func (b *batch) Replay(w kvdb.Writer) error {
 	return b.b.Replay(&replayer{writer: w})
 }
 
+func (b *batch) DeleteRange(start, end []byte) error {
+	for it := b.db.NewIterator(&util.Range{Start: start, Limit: end}, nil); it.Next(); {
+		key := it.Key()
+		b.b.Delete(key)
+		b.size++
+	}
+	return nil
+}
+
 // replayer is a small wrapper to implement the correct replay methods.
 type replayer struct {
 	writer  kvdb.Writer

--- a/leveldb/leveldb_test.go
+++ b/leveldb/leveldb_test.go
@@ -1,0 +1,106 @@
+package leveldb
+
+import (
+	"testing"
+
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
+func TestBatchDeleteRange_KeysInRangeGetDeleted(t *testing.T) {
+	db := newTestDB(t)
+
+	// Insert test keys: "a", "b", "c", "d", "e"
+	keys := [][]byte{[]byte("a"), []byte("b"), []byte("c"), []byte("d"), []byte("e")}
+	for _, key := range keys {
+		if err := db.Put(key, []byte("val-"+string(key)), nil); err != nil {
+			t.Fatalf("failed to put key %s: %v", key, err)
+		}
+	}
+
+	batch := &batch{
+		db: db,
+		b:  new(leveldb.Batch),
+	}
+
+	// Delete keys in range ["b", "d")
+	err := batch.DeleteRange([]byte("b"), []byte("d"))
+	if err != nil {
+		t.Fatalf("DeleteRange failed: %v", err)
+	}
+
+	// Write the batch
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch write failed: %v", err)
+	}
+
+	// Check which keys remain
+	tests := []struct {
+		key      []byte
+		expected bool
+	}{
+		{[]byte("a"), true},
+		{[]byte("b"), false},
+		{[]byte("c"), false},
+		{[]byte("d"), true},
+		{[]byte("e"), true},
+	}
+	for _, test := range tests {
+		ok, err := db.Has(test.key, nil)
+		if err != nil {
+			t.Fatalf("db.Has(%s) failed: %v", test.key, err)
+		}
+		if ok != test.expected {
+			t.Errorf("key %s: expected %v, got %v", test.key, test.expected, ok)
+		}
+	}
+}
+
+func TestBatchDeleteRange_NoKeysInRange(t *testing.T) {
+	db := newTestDB(t)
+
+	// Insert keys "a", "b"
+	keys := [][]byte{[]byte("a"), []byte("b")}
+	for _, key := range keys {
+		if err := db.Put(key, []byte("val"), nil); err != nil {
+			t.Fatalf("failed to put key: %v", err)
+		}
+	}
+
+	batch := &batch{
+		db: db,
+		b:  new(leveldb.Batch),
+	}
+
+	// Delete range ["c", "d") -- no keys in this range
+	err := batch.DeleteRange([]byte("c"), []byte("d"))
+	if err != nil {
+		t.Fatalf("DeleteRange failed: %v", err)
+	}
+	if err := batch.Write(); err != nil {
+		t.Fatalf("batch write failed: %v", err)
+	}
+
+	for _, key := range keys {
+		ok, err := db.Has(key, nil)
+		if err != nil {
+			t.Fatalf("db.Has failed: %v", err)
+		}
+		if !ok {
+			t.Errorf("key %s should not be deleted", key)
+		}
+	}
+}
+
+func newTestDB(t *testing.T) *leveldb.DB {
+	dir := t.TempDir()
+	db, err := leveldb.OpenFile(dir, nil)
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close test db: %v", err)
+		}
+	})
+	return db
+}

--- a/pebble/pebble_test.go
+++ b/pebble/pebble_test.go
@@ -1,0 +1,112 @@
+package pebble
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/pebble"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchDeleteRange_KeysInRangeGetDeleted(t *testing.T) {
+	db := newTestDB(t)
+
+	// Insert some keys
+	keys := [][]byte{
+		[]byte("a"),
+		[]byte("b"),
+		[]byte("c"),
+		[]byte("d"),
+		[]byte("e"),
+	}
+	for _, k := range keys {
+		db.Set(k, []byte("value-"+string(k)), nil)
+	}
+
+	batch := batch{
+		db:   db,
+		b:    db.NewBatch(),
+		size: 0,
+	}
+	// Delete keys in range ["b", "d")
+	err := batch.DeleteRange([]byte("b"), []byte("d"))
+	require.NoError(t, err)
+
+	// Write the batch
+	err = batch.Write()
+	require.NoError(t, err)
+
+	// Check which keys remain
+	testKeys := [][]byte{
+		[]byte("a"),
+		[]byte("d"),
+		[]byte("e"),
+	}
+
+	got := [][]byte{}
+	for _, key := range testKeys {
+		_, closer, err := db.Get(key)
+		if err == nil {
+			got = append(got, key)
+		}
+		closer.Close()
+	}
+	require.ElementsMatch(t, got, testKeys, "Keys not deleted in range")
+}
+
+func TestBatchDeleteRange_NoKeysInRange(t *testing.T) {
+	db := newTestDB(t)
+
+	// Insert some keys
+	keys := [][]byte{
+		[]byte("a"),
+		[]byte("b"),
+		[]byte("c"),
+	}
+	for _, k := range keys {
+		db.Set(k, []byte("value-"+string(k)), nil)
+	}
+
+	batch := batch{
+		db:   db,
+		b:    db.NewBatch(),
+		size: 0,
+	}
+	// Delete keys in range ["d", "e")
+	err := batch.DeleteRange([]byte("d"), []byte("e"))
+	require.NoError(t, err)
+
+	// Write the batch
+	err = batch.Write()
+	require.NoError(t, err)
+
+	// Check which keys remain
+	testKeys := [][]byte{
+		[]byte("a"),
+		[]byte("b"),
+		[]byte("c"),
+	}
+
+	got := [][]byte{}
+	for _, key := range testKeys {
+		_, closer, err := db.Get(key)
+		if err == nil {
+			got = append(got, key)
+		}
+		closer.Close()
+	}
+	require.ElementsMatch(t, got, testKeys, "Keys not deleted in range")
+}
+
+func newTestDB(t *testing.T) *pebble.DB {
+	dir := t.TempDir()
+	db, err := pebble.Open(dir+"testDB", &pebble.Options{})
+	if err != nil {
+		t.Fatalf("failed to open test db: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("failed to close test db: %v", err)
+		}
+	})
+	return db
+}

--- a/synced/store.go
+++ b/synced/store.go
@@ -125,3 +125,11 @@ func (b *syncedBatch) Replay(w kvdb.Writer) error {
 
 	return b.underlying.Replay(w)
 }
+
+// DeleteRange deletes a range of the batch.
+func (b *syncedBatch) DeleteRange(start, end []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.underlying.DeleteRange(start, end)
+}

--- a/table/table.go
+++ b/table/table.go
@@ -130,6 +130,10 @@ func (b *batch) Replay(w kvdb.Writer) error {
 	return b.batch.Replay(&replayer{w, b.prefix})
 }
 
+func (b *batch) DeleteRange(start, end []byte) error {
+	return b.batch.DeleteRange(prefixed(start, b.prefix), prefixed(end, b.prefix))
+}
+
 /*
  * Replayer
  */


### PR DESCRIPTION
This PR is to achieve parity with https://github.com/Fantom-foundation/lachesis-base-sonic/pull/11 - which implemented `DeleteRange` as it is required by the `geth` interface after an upgrade.